### PR TITLE
Added b:vim_gf_diff_base_directory

### DIFF
--- a/autoload/gf/diff.vim
+++ b/autoload/gf/diff.vim
@@ -82,7 +82,38 @@ endfunction
 function! gf#diff#parse_diff_header_line(line)  "{{{2
   " Line -> Maybe (LineNo, LineNo)
   let parts = matchlist(a:line, '\v^diff \-\-git %(a\/)?(\S+) %(b\/)?(\S+)$')
-  return parts == [] ? 0 : parts[1:2]
+
+  if parts == []
+    return 0
+  endif
+
+  let from_path = parts[1]
+  let to_path = parts[2]
+  let directory = get(b:, 'vim_gf_diff_base_directory')
+
+  if empty(directory)
+    return [from_path, to_path]
+  end
+
+  if has('unix')
+    if from_path !~# '^/'
+      let from_path = b:vim_gf_diff_base_directory .. '/' .. from_path
+    endif
+
+    if to_path !~# '^/'
+      let to_path = b:vim_gf_diff_base_directory .. '/' .. to_path
+    endif
+  elseif has("win32")
+    if from_path !~# '^[A-Z]:'
+      let from_path = b:vim_gf_diff_base_directory .. '\' .. from_path
+    endif
+
+    if to_path !~# '^[A-Z]:'
+      let to_path = b:vim_gf_diff_base_directory .. '\' .. to_path
+    endif
+  endif
+
+  return [from_path, to_path]
 endfunction
 
 

--- a/doc/gf-diff.txt
+++ b/doc/gf-diff.txt
@@ -106,6 +106,22 @@ See |gf-user-key-mappings|.
 
 
 
+------------------------------------------------------------------------------
+CONFIGURATION                                          *gf-diff-configuration*
+
+b:vim_gf_diff_base_directory
+
+If your diff uses relative paths, by default, vim-gf-diff uses |getcwd()| to
+resolve to absolute paths. b:vim_gf_diff_base_directory specifies an
+alternate directory to resolve relative paths into absolute paths.
+
+let b:vim_gf_diff_base_directory = "/some/absolute/directory"
+
+Now all relative paths will be be relative to "/some/absolute/directory"
+
+
+
+
 ==============================================================================
 EXAMPLES                                                    *gf-diff-examples*
 


### PR DESCRIPTION
When using [vim-fugitive](https://github.com/tpope/vim-fugitive), the `:Git add -p` command drops into a diff terminal. This diff view shows paths that are relative to the root of the git repository but I'm frequently cd'ed somewhere else, which causes `gf` to fail. To make sure `gf` always works in this case, I added a root directory that points to the git repository root, using `b:vim_gf_diff_base_directory`. It works for me but I made this PR in case you find it useful